### PR TITLE
making 'release.yml' not run on pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Build project using muddler and upload artifact
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
probably should only run on an update to main rather than a pr to main.