### PR TITLE
1.3.5 - Bugfix + a QoL improvement for magic users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.3.5
+
+*20/9/2024*
+
+* Fixed bug that made MUDKIP not respond to `qs` when using a persona who has magic.
+* Added a couple of triggers to (hopefully) update one's stats if after using a spell.
+* (I have a persona who has magic again so I've only just noticed and fixed these issues xd)
+
 ## 1.3.4
 
 *16/9/2024*

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ Consider taking a look at the documentation of muddler if you wish to contribute
 
 ## CHANGELOG
 
-* **1.3.4** (`16/9/2024`)
-  * Found workaround for issue which turned the helpful tooltips on the stamina/magic bars into unusable black rectangles.
+* **1.3.5** (`20/9/2024`)
+  * Fixed bug that made MUDKIP not respond to `qs` when using a persona who has magic.
+  * Added a couple of triggers to (hopefully) update one's stats after using a spell.
+  * (I have a persona who has magic again so I've only just noticed and fixed these issues xd)
 
 See [CHANGELOG.md](https://github.com/11BelowStudio/MUDKIP_Mud2/blob/main/CHANGELOG.md) for the full changelog.
 

--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "MUDKIP_Mud2",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": "11BelowStudio",
   "title": "Multi User Dungeon Kool Informational Package (for playing MUD2 with Mudlet)",
   "outputFile": true,

--- a/src/triggers/MUDKIP_Mud2/spell_used_autofes.lua
+++ b/src/triggers/MUDKIP_Mud2/spell_used_autofes.lua
@@ -1,0 +1,3 @@
+if MUDKIP_Mud2:isInGame() then
+  send("￼␛-[fes￼␛-]")
+end

--- a/src/triggers/MUDKIP_Mud2/triggers.json
+++ b/src/triggers/MUDKIP_Mud2/triggers.json
@@ -134,7 +134,7 @@
     "isActive": "yes",
     "patterns": [
       {
-        "pattern":"^(\\*)?eff str (?<effStr>\\d+)\\h*eff dex (?<effDex>\\d+)\\h*sta (?<sta>\\d+)/(?<maxSta>\\d+)\\h*(mag (?<mag>\\d+)\\h*)?pts (?<pts>\\d+(,\\d+)*).*$",
+        "pattern":"^(\\*)?eff str (?<effStr>\\d+)\\h*eff dex (?<effDex>\\d+)\\h*sta (?<sta>\\d+)\/(?<maxSta>\\d+)\\h*(mag (?<mag>\\d+)\\h*)?pts (?<pts>\\d+(,\\d+)*).*$",
         "type": "regex"
       }
     ]
@@ -148,7 +148,7 @@
         "type": "regex"
       },
       {
-        "pattern":"^(\\*)?Stamina=(?<stam>\\d+)/(?<maxStam>\\d+)\\.$",
+        "pattern":"^(\\*)?Stamina=(?<stam>\\d+)\/(?<maxStam>\\d+)\\.$",
         "type": "regex"
       },
       {
@@ -156,7 +156,7 @@
         "type": "regex"
       },
       {
-        "pattern": "^(The )?(\\S+ )*\\S+ hits you \\((?<stam>\\d+)/(?<maxStam>\\d+)\\).$",
+        "pattern": "^(The )?(\\S+ )*\\S+ hits you \\((?<stam>\\d+)\/(?<maxStam>\\d+)\\).$",
         "type": "regex"
       }
     ]

--- a/src/triggers/MUDKIP_Mud2/triggers.json
+++ b/src/triggers/MUDKIP_Mud2/triggers.json
@@ -134,7 +134,7 @@
     "isActive": "yes",
     "patterns": [
       {
-        "pattern":"^(\\*)?eff str (?<effStr>\\d+)\\h*eff dex (?<effDex>\\d+)\\h*sta (?<sta>\\d+)/(?<maxSta>\\d+)\\h*(mag (?<mag>)\\h*)?pts (?<pts>\\d+(,\\d+)*).*$",
+        "pattern":"^(\\*)?eff str (?<effStr>\\d+)\\h*eff dex (?<effDex>\\d+)\\h*sta (?<sta>\\d+)/(?<maxSta>\\d+)\\h*(mag (?<mag>\\d+)\\h*)?pts (?<pts>\\d+(,\\d+)*).*$",
         "type": "regex"
       }
     ]
@@ -185,6 +185,21 @@
             "type": "regex"
           }
         ]
+      }
+    ]
+  },
+  {
+    "name": "spell_used_autofes",
+    "isActive": "yes",
+    "multiline": "yes",
+    "patterns": [
+      {
+        "pattern":"15,0",
+        "type": "color"
+      },
+      {
+        "pattern":"^Your spell (work|fail)ed!$",
+        "type":"regex"
       }
     ]
   }


### PR DESCRIPTION
* Fixed bug that made MUDKIP not respond to `qs` when using a persona who has magic.
* Added a couple of triggers to (hopefully) update one's stats if after using a spell.
* (I have a persona who has magic again so I've only just noticed and fixed these issues xd)